### PR TITLE
郵便番号APIで住所検索ができる

### DIFF
--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -59,6 +59,10 @@
       .postal-code {
         width: 100px;
       }
+
+      #search_address {
+        margin-left: 10px;
+      }
     }
   }
 

--- a/app/javascript/packs/post_code.js
+++ b/app/javascript/packs/post_code.js
@@ -1,0 +1,24 @@
+const searchAddress = document.getElementById("search_address");
+
+function handleClick(event) {
+    const postalCode = document.getElementById("order_postal_code").value;
+    // 郵便番号で"-"ありでも検索できるように、replaceを使って、"-"を削除した。
+    const url = `https://zipcloud.ibsnet.co.jp/api/search?zipcode=${postalCode.replace("-", "")}`;
+
+    // fetchがXHRに比べて、モダンでコード量が少なく書けるので、fetchを選択しました。
+    fetch(url)
+        .then(function (response) {
+            return response.json();
+        })
+        .then(function (address) {
+            // 横に長いのが見づらいので、変数に代入しました。
+            prefecture = address.results[0].address1;
+            city = address.results[0].address2;
+            locality = address.results[0].address3;
+            const shipping_address = prefecture +　city + locality
+            document.getElementById("order_postal_code").value = postalCode;
+            document.getElementById("order_shipping_address").value = shipping_address;
+        });
+}
+
+searchAddress.addEventListener("click", handleClick);

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,3 +1,6 @@
+<!--このページのみJSを読み込むため-->
+<%= javascript_pack_tag "post_code" %>
+
 <div class="order">
 
   <h1>注文確認</h1>
@@ -29,7 +32,9 @@
       <h2>配送先</h2>
       <div class="field">
         <%= form.label :postal_code, "〒：" %>
-        <%= form.number_field :postal_code, class: "postal-code" %>
+<!--        number_fieldでも"-"が入力できるので、text_fieldに変更して"-"ありでも検索できるようにした-->
+        <%= form.text_field :postal_code, class: "postal-code" %>
+        <%= button_tag "住所検索", id: "search_address", type: "button" %>
       </div>
 
       <div class="field">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_25_141608) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_20_074628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string "namespace"
+    t.text "body"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.string "author_type"
+    t.bigint "author_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author"
+    t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource"
+  end
+
+  create_table "admin_users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
 
   create_table "carts", force: :cascade do |t|
     t.bigint "product_id", null: false


### PR DESCRIPTION
## 何を解決するのか

- 郵便番号APIを使って、住所を自動入力できるようにする。
- ユーザーの利便性が向上する。

## レビュー関連

- 該当タスク：[郵便番号APIを導入し住所を自動入力できるようにする](https://www.notion.so/shunju/API-7088ffca1a914ce5b20bdeac753d9e55?pvs=4)

### 不安なところ・特に見てほしいところ

- 住所を自動取得できるが、取得までに時間がかかることがある。

### レビューポイント

- JSの非同期リクエストの中で、下記理由により、fetchを選択した。
・XHRよりモダンで、コード量が少ない。
・既存スクリプトにXHRがない。

- JSは、住所自動取得を使うordersのnewを指定して、
ファイル読み込みをしている。

- 郵便番号は”-”あり/なしに関わらず、ボタンを押すと検索できる。

- 勉強のために、コメントで判断軸を書いている。
コメントは無視して問題ないです。

### 動作確認（実装状況のスクショなど）
<details>
  <summary>
    実装状況
  </summary>
<img width="1470" alt="スクリーンショット 2023-12-05 16 23 46" src="https://github.com/shunjuio/ec_app_nomura/assets/105269891/8d02880b-5923-41dd-96d7-c1576678eb24">

</details>